### PR TITLE
feat: support latest React version (17 and above)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "micromatch": "4.0.4"
   },
   "peerDependencies": {
-    "react": "17.0.2",
+    "react": ">=17",
     "vite": "^2.7.13"
   }
 }


### PR DESCRIPTION
### What is the issue
This plugin has a peerDependency for react set to version `17.0.2`. It is not compatible  with the [latest version of react](https://reactjs.org/blog/2022/03/29/react-v18.html), which is the version 18.
It throws the following error :
```
Could not resolve dependency:
peer react@"17.0.2" from vite-plugin-svgr-component@1.0.0
node_modules/vite-plugin-svgr-component
dev vite-plugin-svgr-component@"1.0.0" from the root project
```

### Proposed solution
This solution intend to specifically state the peerDependencies for react, and allow everyone to use this plugin with the latest version of React.
